### PR TITLE
Increase context window size

### DIFF
--- a/llm/ollama.go
+++ b/llm/ollama.go
@@ -84,6 +84,8 @@ func (o Ollama) chatRequest(messages []api.Message) api.ChatRequest {
 
 	stream := false
 	req.Stream = &stream
+	num_ctx := 32768
+	opts["num_ctx"] = &num_ctx
 
 	if o.params.Temperature != nil {
 		opts["temperature"] = *o.params.Temperature


### PR DESCRIPTION
By default, Ollama uses a context window size of 4096 tokens.

This can be overridden with the OLLAMA_CONTEXT_LENGTH environment variable. For example, to set the default context window to 8K, use:

OLLAMA_CONTEXT_LENGTH=8192 ollama serve